### PR TITLE
Depends on railties and activerecord instead of rails

### DIFF
--- a/i18n_generators.gemspec
+++ b/i18n_generators.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |s|
 
   s.licenses = ['MIT']
 
-  s.add_runtime_dependency 'rails', '>= 3.0.0'
+  s.add_runtime_dependency 'railties', '>= 3.0.0'
+  s.add_runtime_dependency 'activerecord', '>= 3.0.0'
   s.add_development_dependency 'test-unit'
   s.add_development_dependency 'test-unit-rr'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
i18n_generators provides only generators using activerecord.
It is enough to depend on railties and activerecord, not rails.
(rails depends on some extra gems such as actioncable and activejob, etc.)