### PR TITLE
Fix generating default locale including hyphen

### DIFF
--- a/lib/generators/i18n_locale/i18n_locale_generator.rb
+++ b/lib/generators/i18n_locale/i18n_locale_generator.rb
@@ -20,7 +20,7 @@ class I18nLocaleGenerator < Rails::Generators::NamedBase
   end
 
   def add_locale_config(config_contents)
-    new_line = "    config.i18n.default_locale = :#{locale_name}"
+    new_line = "    config.i18n.default_locale = #{locale_name.to_sym.inspect.gsub('"', '\'')}"
     if config_contents =~ /\n *config\.i18n\.default_locale *=/
       config_contents.sub(/ *config\.i18n\.default_locale *=.*/, new_line)
     elsif config_contents =~ /\n *#? *config\.i18n\.default_locale *=/

--- a/test/i18n_locale_command_test.rb
+++ b/test/i18n_locale_command_test.rb
@@ -2,13 +2,14 @@ require 'test_helper'
 require 'generators/i18n_locale/i18n_locale_generator'
 
 class I18nLocaleGeneratorTest < Test::Unit::TestCase
-  setup do
-    @generator = I18nLocaleGenerator.new(['ja'])
-  end
+  sub_test_case 'ja locale' do
+    setup do
+      @generator = I18nLocaleGenerator.new(['ja'])
+    end
 
-  sub_test_case 'add_locale_config' do
-    test 'when i18n.default_locale is configured in environment.rb' do
-      config = <<-CONFIG
+    sub_test_case 'add_locale_config' do
+      test 'when i18n.default_locale is configured in environment.rb' do
+        config = <<-CONFIG
 module Tes
   class Application < Rails::Application
     config.i18n.default_locale = :de
@@ -16,17 +17,17 @@ module Tes
 end
 CONFIG
 
-      assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
+        assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
 module Tes
   class Application < Rails::Application
     config.i18n.default_locale = :ja
   end
 end
 RESULT
-    end
+      end
 
-    test 'when i18n.default_locale config is commented in environment.rb' do
-      config = <<-CONFIG
+      test 'when i18n.default_locale config is commented in environment.rb' do
+        config = <<-CONFIG
 module Tes
   class Application < Rails::Application
     # config.i18n.default_locale = :de
@@ -34,17 +35,17 @@ module Tes
 end
 CONFIG
 
-      assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
+        assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
 module Tes
   class Application < Rails::Application
     config.i18n.default_locale = :ja
   end
 end
 RESULT
-    end
+      end
 
-    test 'when i18n.default_locale is not written in environment.rb' do
-      config = <<-CONFIG
+      test 'when i18n.default_locale is not written in environment.rb' do
+        config = <<-CONFIG
 module Tes
   class Application < Rails::Application
     something goes here.
@@ -53,7 +54,7 @@ module Tes
 end
 CONFIG
 
-      assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
+        assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
 module Tes
   class Application < Rails::Application
     config.i18n.default_locale = :ja
@@ -62,6 +63,72 @@ module Tes
   end
 end
 RESULT
+      end
+    end
+  end
+
+  sub_test_case 'zh-CN locale' do
+    setup do
+      @generator = I18nLocaleGenerator.new(['zh-CN'])
+    end
+
+    sub_test_case 'add_locale_config' do
+      test 'when i18n.default_locale is configured in environment.rb' do
+        config = <<-CONFIG
+module Tes
+  class Application < Rails::Application
+    config.i18n.default_locale = :de
+  end
+end
+CONFIG
+
+        assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
+module Tes
+  class Application < Rails::Application
+    config.i18n.default_locale = :'zh-CN'
+  end
+end
+RESULT
+      end
+
+      test 'when i18n.default_locale config is commented in environment.rb' do
+        config = <<-CONFIG
+module Tes
+  class Application < Rails::Application
+    # config.i18n.default_locale = :de
+  end
+end
+CONFIG
+
+        assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
+module Tes
+  class Application < Rails::Application
+    config.i18n.default_locale = :'zh-CN'
+  end
+end
+RESULT
+      end
+
+      test 'when i18n.default_locale is not written in environment.rb' do
+        config = <<-CONFIG
+module Tes
+  class Application < Rails::Application
+    something goes here.
+    bla bla bla...
+  end
+end
+CONFIG
+
+        assert_equal <<-RESULT, @generator.send(:add_locale_config, config)
+module Tes
+  class Application < Rails::Application
+    config.i18n.default_locale = :'zh-CN'
+    something goes here.
+    bla bla bla...
+  end
+end
+RESULT
+      end
     end
   end
 end


### PR DESCRIPTION
I fixed I18nLocaleGenerator#add_locale_config when the locale includes a hyphen (e.g.: zh-CN).

`rails g i18n_locale zh-CN`
expects to generate
```
# config/application.rb
config.i18n.default_locale = :'zh-CN'
```
but now, generates
```
config.i18n.default_locale = :zh-CN
```
I guess that this behavior continues since https://github.com/amatsuda/i18n_generators/commit/7f6841f8e641c52d236174306c5d888474ccdb36